### PR TITLE
Changed bright black color

### DIFF
--- a/One Dark.itermcolors
+++ b/One Dark.itermcolors
@@ -189,13 +189,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.16862745583057404</real>
+		<real>0.364705890417099</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.14509804546833038</real>
+		<real>0.34117648005485535</real>
 		<key>Red Component</key>
-		<real>0.12941177189350128</real>
+		<real>0.32549020648002625</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>

--- a/One Dark.itermcolors
+++ b/One Dark.itermcolors
@@ -189,13 +189,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.364705890417099</real>
+		<real>0.46274510025978088</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.34117648005485535</real>
+		<real>0.46274510025978088</real>
 		<key>Red Component</key>
-		<real>0.32549020648002625</real>
+		<real>0.46274510025978088</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>


### PR DESCRIPTION
### Description

Closes #5 

Changing the bright black color allows iTerm to properly see auto completion

### Screenshots

Previous

![image](https://user-images.githubusercontent.com/12074633/70144112-3bdef280-166b-11ea-9c90-223975af938e.png)

![image](https://user-images.githubusercontent.com/12074633/70144140-4d27ff00-166b-11ea-96a9-c76227fb65da.png)

New

![image](https://user-images.githubusercontent.com/12074633/70144094-308bc700-166b-11ea-8fcd-0cedc2a7b319.png)

![image](https://user-images.githubusercontent.com/12074633/70144168-5913c100-166b-11ea-9944-5215631e45e7.png)